### PR TITLE
create separate positions for each face for texture mapping

### DIFF
--- a/obj2sc.js
+++ b/obj2sc.js
@@ -18,6 +18,7 @@ process.stdin
     var faces = []
     var uv = []
     var normals = []
+    var positions = []
 
     str.join('').split('\n').forEach(function (line) {
       var toks = line.split(/\s+/)
@@ -32,9 +33,11 @@ process.stdin
         for (var i = 1; i < toks.length; i++) {
           var vtn = toks[i].split('/')
           var vi = (vtn[0]-1)|0
-          f.push(vi)
-          if (vtn[1]) uv[vi] = vt[(vtn[1]-1)|0] // texture index
-          if (vtn[2]) normals[vi] = vn[(vtn[2]-1)|0] // normal index
+          var pi = positions.length
+          positions.push(verts[vi])
+          f.push(pi)
+          if (vtn[1]) uv[pi] = vt[(vtn[1]-1)|0] // texture index
+          if (vtn[2]) normals[pi] = vn[(vtn[2]-1)|0] // normal index
         }
         if (f.length === 3) faces.push(f)
         else {
@@ -46,7 +49,7 @@ process.stdin
     })
 
     var data = {
-      positions: verts,
+      positions: positions,
       cells: faces
     }
     if (uv.length) {


### PR DESCRIPTION
Before this change, texture mapping a simple cube looked like this:

<img width="747" alt="screen shot 2018-08-24 at 2 42 27 am" src="https://user-images.githubusercontent.com/970121/44578064-7e670f00-a747-11e8-9ef9-77d3750382c8.png">

Now it looks like this:

<img width="840" alt="screen shot 2018-08-24 at 2 42 09 am" src="https://user-images.githubusercontent.com/970121/44578070-8757e080-a747-11e8-8f1d-86d4d2b8f928.png">
